### PR TITLE
Add log_dir to ToolAttachWithRL.srv.

### DIFF
--- a/srv/ToolAttachWithRL.srv
+++ b/srv/ToolAttachWithRL.srv
@@ -1,5 +1,5 @@
 string tool_id
-string date_time
+string log_dir
 ---
 bool evaluate
 string message

--- a/srv/ToolAttachWithRL.srv
+++ b/srv/ToolAttachWithRL.srv
@@ -1,5 +1,5 @@
 string tool_id
-string log_dir
+string date_time
 ---
 bool evaluate
 string message

--- a/srv/ToolAttachWithRL.srv
+++ b/srv/ToolAttachWithRL.srv
@@ -3,4 +3,3 @@ string date_time
 ---
 bool evaluate
 string message
-

--- a/srv/ToolAttachWithRL.srv
+++ b/srv/ToolAttachWithRL.srv
@@ -1,4 +1,6 @@
 string tool_id
+string date_time
 ---
 bool evaluate
 string message
+


### PR DESCRIPTION
Background
Add `string log_dir` to ToolAttachWithRL.srv.
We want rltc to know the log directory when cmd attach is called for tool_change, so that the rollout data can be saved in the right action log directory. 
What's new

❌ bug fixes
❌ New feature is accompanied by new test: [name and description of new test].
Related work

❌ This PR needs [link]
❌ [link] needs this PR
TODOs / Nice-To-Haves 


❌ [Add new unit test for new feature.]
❌ [Add new system test for new feature.]
Tests

✅ Tested:
Quality

✅ New code is purely Python 3.8 and up.
✅ New code passed all 24 pre-commit hooks including unit tests.
Note to reviewers
